### PR TITLE
[WIP] nodeproxy shim

### DIFF
--- a/v8env/src/fly/data.ts
+++ b/v8env/src/fly/data.ts
@@ -30,7 +30,7 @@ export class Collection {
    * @param key key for data
    * @param obj value to store
    */
-  put(key: string, obj: string): Promise<boolean> {
+  put(key: string, obj: unknown): Promise<boolean> {
     const fbb = flatbuffers.createBuilder();
     const fbbColl = fbb.createString(this.name);
     const fbbKey = fbb.createString(key);

--- a/v8env/src/globals.ts
+++ b/v8env/src/globals.ts
@@ -23,6 +23,7 @@ import flyCache from './fly/cache';
 import flyHttp from './fly/http'
 import { loadModule } from "./module_loader";
 import { installDevTools } from "./dev-tools";
+import { installNodeProxyShim } from "./nodeproxy-shim";
 
 declare global {
   interface Window {
@@ -119,3 +120,5 @@ window.DNSRecordType = dns.DNSRecordType;
 window.DNSMessageType = dns.DNSMessageType;
 window.DNSOpCode = dns.DNSOpCode;
 window.DNSResponseCode = dns.DNSResponseCode;
+
+installNodeProxyShim(window);

--- a/v8env/src/nodeproxy-shim/bridge.ts
+++ b/v8env/src/nodeproxy-shim/bridge.ts
@@ -1,0 +1,90 @@
+import flyCache, { CacheSetOptions } from '../fly/cache';
+import flyData from '../fly/data';
+
+type CallbackFn<T> = (err: string | null, val?: T) => void;
+type OkCallback = CallbackFn<boolean>
+
+const handlers = {
+  flyCacheDel: (key: string, cb: OkCallback) => {
+    flyCache.del(key)
+      .then(ok => cb(undefined, ok))
+      .catch(err => cb(err, false));
+  },
+  flyCacheSet: (key: string, value: string | ArrayBuffer, options: any, cb: OkCallback) => {
+    flyCache.set(key, value, convertCacheSetOptions(options))
+      .then(ok => cb(undefined, ok))
+      .catch(err => cb(err, false));
+  },
+  flyCacheGet: (key: string, cb: CallbackFn<ArrayBuffer | SharedArrayBuffer>) => {
+    flyCache.get(key)
+      .then(val => cb(undefined, val))
+      .catch(err => cb(err, undefined));
+  },
+  flyCacheExpire: (key: string, ttl: number, cb: OkCallback) => {
+    flyCache.expire(key, ttl)
+      .then(ok => cb(undefined, ok))
+      .catch(err => cb(err, false));
+  },
+  flyCacheGetMulti: notImplementedBridgeHandler,
+  flyCacheSetTags: notImplementedBridgeHandler,
+  flyCachePurgeTags: notImplementedBridgeHandler,
+  flyCacheNotify: notImplementedBridgeHandler,
+
+  "fly.Data.put": (collectionName: string, key: string, obj: string, cb: OkCallback) => {
+    flyData.collection(collectionName).put(key, JSON.parse(obj))
+      .then(ok => cb(undefined, ok))
+      .catch(err => cb(err, false));
+  },
+  "fly.Data.get": (collectionName: string, key: string, cb: CallbackFn<any>) => {
+    flyData.collection(collectionName).get(key)
+      .then(val => cb(undefined, JSON.stringify(val)))
+      .catch(err => cb(err, false));
+  },
+  "fly.Data.del": (collectionName: string, key: string, cb: OkCallback) => {
+    flyData.collection(collectionName).del(key)
+      .then(ok => cb(undefined, ok))
+      .catch(err => cb(err, false));
+  },
+  "fly.Data.dropCollection": (collectionName: string, cb: OkCallback) => {
+    flyData.dropCollection(collectionName)
+      .then(ok => cb(undefined, ok))
+      .catch(err => cb(err, false));
+  },
+};
+
+export function dispatch(name: string, ...args: unknown[]) {
+  console.log("nodeproxy bridge dispatch", { name, args });
+
+  const handler = handlers[name];
+  if (!handler) {
+    throw new Error(`Unhandled nodeproxy bridge invocation: ${name}`);
+  }
+
+  handler(...args);
+}
+
+function convertCacheSetOptions(options: unknown): CacheSetOptions | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  if (typeof options === "string") {
+    const parsedOptions = JSON.parse(options);
+
+    if (typeof parsedOptions === "number") {
+      return {
+        ttl: parsedOptions
+      };
+    } else if (parsedOptions !== null && typeof parsedOptions === "object") {
+      return parsedOptions;
+    }
+  }
+
+  console.warn("Expected flyCacheSet options to be undefined or JSON serialized number or CacheSetOptions, got:", options);
+  return undefined;
+}
+
+function notImplementedBridgeHandler(...args: unknown[]) {
+  throw new Error(`Unimplemented nodeproxy bridge handler: ${JSON.stringify(args)}`);
+}
+

--- a/v8env/src/nodeproxy-shim/index.ts
+++ b/v8env/src/nodeproxy-shim/index.ts
@@ -1,0 +1,5 @@
+import * as bridge from "./bridge";
+
+export function installNodeProxyShim(target: any) {
+  target.bridge = bridge;
+}


### PR DESCRIPTION
This allows apps targeting nodeproxy apis to run on the rust proxy without recompilation during the transition. 

Current supported:
- [x] @fly/data
- [ ] @fly/cache (partial, still missing `flyCacheGetMulti`, `flyCacheSetTags`, `flyCachePurgeTags`, `flyCacheNotify`)
- [ ] @fly/image
- [ ] `app` global
- [ ] DOM apis (`Document`)

Fixes #24 

