### PR TITLE
Move window.app -> window.fly.app

### DIFF
--- a/distributed-fly/src/runtime_selector.rs
+++ b/distributed-fly/src/runtime_selector.rs
@@ -95,7 +95,7 @@ impl RuntimeSelector for DistributedRuntimeSelector {
                 let merged_conf = rel.clone().parsed_config().unwrap();
                 rt.eval(
                     "<app config>",
-                    &format!("window.app = {{ config: {} }};", merged_conf),
+                    &format!("window.fly.app = {{ config: {} }};", merged_conf),
                 );
                 rt.eval("app.js", &rel.source);
                 let app = rel.app;

--- a/v8env/src/app.ts
+++ b/v8env/src/app.ts
@@ -1,0 +1,7 @@
+export interface AppRelease {
+  name: string;
+  version: number;
+  env: string;
+  region?: string;
+  config: unknown
+}

--- a/v8env/src/globals.ts
+++ b/v8env/src/globals.ts
@@ -22,6 +22,7 @@ import flyHttp from './fly/http'
 import { loadModule } from "./module_loader";
 import { installDevTools } from "./dev-tools";
 import * as streams from "./streams";
+import { AppRelease } from "./app";
 
 declare global {
   interface Window {
@@ -60,6 +61,7 @@ declare global {
     data: typeof flyData
     http: typeof flyHttp
     Image: typeof Image
+    app: AppRelease;
   }
   // TODO: remove
   const fly: Fly


### PR DESCRIPTION
Closes #32. Already shimmed in superfly/fly#207. Note the `app` object isn't being set in the standalone runtime yet, we'll need to revisit.