### PR TITLE
Reduce log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,14 +5,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -511,7 +503,6 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -646,7 +637,6 @@ dependencies = [
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1103,14 +1093,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "md5"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memchr"
@@ -1774,18 +1756,6 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1807,11 +1777,6 @@ dependencies = [
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -2317,20 +2282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog-envlogger"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "slog-json"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,23 +2479,6 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2974,11 +2908,6 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -3124,7 +3053,6 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
@@ -3245,7 +3173,6 @@ dependencies = [
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -3318,10 +3245,8 @@ dependencies = [
 "checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
-"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
@@ -3375,7 +3300,6 @@ dependencies = [
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
 "checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
-"checksum slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7c6685180086bf58624e92cb3da5d5f013bebd609454926fc8e2ac6345d384b"
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 "checksum slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "60c04b4726fa04595ccf2c2dad7bcd15474242c4c5e109a8a376e8a2c9b1539a"
 "checksum slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
@@ -3398,8 +3322,6 @@ dependencies = [
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiff 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2cc6c4fd13cb1cfd20abdb196e794ceccb29371855b7e7f575945f920a5b3c2"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
@@ -3439,7 +3361,6 @@ dependencies = [
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ sha-1 = "0.7"
 sha2 = "0.7"
 slog = {version="2.4.1", features = ["max_level_debug", "release_max_level_info"] }
 slog-async = "2.3.0"
-slog-envlogger = "2.1.0"
 slog-scope = "4.1.1"
 slog-stdlog = "3.0.2"
 slog-term = "2.4.0"

--- a/distributed-fly/Cargo.toml
+++ b/distributed-fly/Cargo.toml
@@ -30,7 +30,6 @@ serde_json = "*"
 sha2 = "0.8"
 slog = {version="2.4.1", features = ["max_level_debug", "release_max_level_info"] }
 slog-async = "2.3.0"
-slog-envlogger = "2.1.0"
 slog-json = "2.3.0"
 slog-scope = "4.1.1"
 slog-stdlog = "3.0.2"

--- a/distributed-fly/src/main.rs
+++ b/distributed-fly/src/main.rs
@@ -83,7 +83,7 @@ lazy_static! {
             "level" => slog::FnValue(move |rinfo : &slog::Record| {
                 numeric_level(rinfo.level())
             }),
-            "ts" => slog::PushFnValue(move |_ : &slog::Record, ser| {
+            "timestamp" => slog::PushFnValue(move |_ : &slog::Record, ser| {
                 ser.emit(chrono::Local::now().to_rfc3339())
             }),
         )
@@ -101,7 +101,7 @@ fn main() {
             "level" => slog::FnValue(move |rinfo : &slog::Record| {
                 numeric_level(rinfo.level())
             }),
-            "ts" => slog::PushFnValue(move |_ : &slog::Record, ser| {
+            "timestamp" => slog::PushFnValue(move |_ : &slog::Record, ser| {
                 ser.emit(chrono::Local::now().to_rfc3339())
             }),
         ),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,15 +1,50 @@
-use slog::{o, Drain, Logger};
+use slog::{o, Drain, Level, Logger};
+use slog_async::Async;
 use slog_scope::GlobalLoggerGuard;
+use slog_term::term_full;
+use std::env;
 
 pub fn configure() -> (GlobalLoggerGuard, Logger) {
-  let decorator = slog_term::TermDecorator::new().build();
-  let drain = slog_term::FullFormat::new(decorator).build().fuse();
-  let drain = slog_async::Async::new(drain).build().fuse();
-  let logger = slog::Logger::root(drain, o!("build" => crate::build_number()));
-  let runtime_logger = logger.new(o!("source" => "rt"));
-  let app_logger = logger.new(o!("source" => "app"));
+  let runtime_logger = Logger::root(
+    Async::default(
+      term_full()
+        .filter_level(log_level_from_env("FLY_LOG_LEVEL", Level::Warning))
+        .fuse(),
+    )
+    .fuse(),
+    o!(
+      "build" => crate::build_number(),
+      "source" => "rt",
+    ),
+  );
+
+  let app_logger = Logger::root(
+    Async::default(
+      term_full()
+        .filter_level(log_level_from_env("LOG_LEVEL", Level::Debug))
+        .fuse(),
+    )
+    .fuse(),
+    o!(
+      "build" => crate::build_number(),
+      "source" => "app",
+    ),
+  );
+
   let _guard = slog_scope::set_global_logger(runtime_logger);
   slog_stdlog::init().unwrap();
 
   return (_guard, app_logger);
+}
+
+pub fn log_level_from_env(name: &str, default: Level) -> Level {
+  match env::var(name).unwrap_or_default().as_ref() {
+    "TRACE" => Level::Trace,
+    "DEBUG" => Level::Debug,
+    "INFO" => Level::Info,
+    "WARN" => Level::Warning,
+    "WARNING" => Level::Warning,
+    "ERROR" => Level::Error,
+    _ => default,
+  }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,46 +5,42 @@ use slog_term::term_full;
 use std::env;
 
 pub fn configure() -> (GlobalLoggerGuard, Logger) {
-  let runtime_logger = Logger::root(
-    Async::default(
-      term_full()
-        .filter_level(log_level_from_env("FLY_LOG_LEVEL", Level::Warning))
-        .fuse(),
-    )
-    .fuse(),
-    o!(
-      "build" => crate::build_number(),
-      "source" => "rt",
-    ),
-  );
+    let root_logger = Logger::root(
+        Async::default(term_full().fuse()).fuse(),
+        o!(
+          "build" => crate::build_number(),
+        ),
+    );
 
-  let app_logger = Logger::root(
-    Async::default(
-      term_full()
-        .filter_level(log_level_from_env("LOG_LEVEL", Level::Debug))
-        .fuse(),
-    )
-    .fuse(),
-    o!(
-      "build" => crate::build_number(),
-      "source" => "app",
-    ),
-  );
+    let runtime_logger = Logger::root(
+        root_logger
+            .new(o!())
+            .filter_level(log_level_from_env("FLY_LOG_LEVEL", Level::Warning))
+            .fuse(),
+        o!("source" => "rt"),
+    );
 
-  let _guard = slog_scope::set_global_logger(runtime_logger);
-  slog_stdlog::init().unwrap();
+    let app_logger = Logger::root(
+        root_logger
+            .filter_level(log_level_from_env("LOG_LEVEL", Level::Debug))
+            .fuse(),
+        o!("source" => "app"),
+    );
 
-  return (_guard, app_logger);
+    let _guard = slog_scope::set_global_logger(runtime_logger);
+    slog_stdlog::init().unwrap();
+
+    return (_guard, app_logger);
 }
 
 pub fn log_level_from_env(name: &str, default: Level) -> Level {
-  match env::var(name).unwrap_or_default().as_ref() {
-    "TRACE" => Level::Trace,
-    "DEBUG" => Level::Debug,
-    "INFO" => Level::Info,
-    "WARN" => Level::Warning,
-    "WARNING" => Level::Warning,
-    "ERROR" => Level::Error,
-    _ => default,
-  }
+    match env::var(name).unwrap_or_default().as_ref() {
+        "TRACE" => Level::Trace,
+        "DEBUG" => Level::Debug,
+        "INFO" => Level::Info,
+        "WARN" => Level::Warning,
+        "WARNING" => Level::Warning,
+        "ERROR" => Level::Error,
+        _ => default,
+    }
 }

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -70,14 +70,14 @@ pub trait ModuleResolverManager: Send + Sync {
  * Parse url or join it to the working url if it's relative. working_url_str << MUST BE AN ABSOLUTE PATH.
  */
 fn parse_url(url_str: &str, working_url_str: &str) -> Result<url::Url, url::ParseError> {
-    info!("parse_url {} from {}", &url_str, &working_url_str);
+    debug!("parse_url {} from {}", &url_str, &working_url_str);
     // TODO: Add some additional logic to this thing to account for file paths without the "file://" protocol denotation.
     let mut url_parsed = match url::Url::parse(url_str) {
         Ok(v) => v,
         Err(e) => {
             if e == url::ParseError::RelativeUrlWithoutBase {
                 // If the url is relative join it to the working path.
-                println!("Url relative: {}", url_str);
+                trace!("Url relative: {}", url_str);
                 let working_url_parsed = url::Url::parse(working_url_str)?;
                 let final_url = working_url_parsed.join(url_str)?;
                 final_url
@@ -160,9 +160,10 @@ impl ModuleResolver for LocalDiskModuleResolver {
             Some(v) => v.origin_url,
             None => self.default_working_url.clone(),
         };
-        println!(
+        trace!(
             "resolve_module {} from {}",
-            module_specifier, referer_origin_url
+            module_specifier,
+            referer_origin_url
         );
 
         let module_specifier_url = parse_url(module_specifier, referer_origin_url.as_str())?;
@@ -179,7 +180,7 @@ impl ModuleResolver for LocalDiskModuleResolver {
             });
         }
         let did_set = module_file_path.set_extension("ts");
-        info!("trying module {} ({})", module_file_path.display(), did_set);
+        trace!("trying module {} ({})", module_file_path.display(), did_set);
         if module_file_path.is_file() {
             return Ok(ModuleSourceData {
                 origin_url: url::Url::from_file_path(module_file_path.clone())
@@ -190,7 +191,7 @@ impl ModuleResolver for LocalDiskModuleResolver {
             });
         }
         let did_set = module_file_path.set_extension("js");
-        info!("trying module {} ({})", module_file_path.display(), did_set);
+        trace!("trying module {} ({})", module_file_path.display(), did_set);
         if module_file_path.is_file() {
             return Ok(ModuleSourceData {
                 origin_url: url::Url::from_file_path(module_file_path.clone())
@@ -235,9 +236,10 @@ impl ModuleResolver for FunctionModuleResolver {
             Some(v) => v.origin_url,
             None => "".to_string(),
         };
-        println!(
+        trace!(
             "resolve_module {} from {}",
-            module_specifier, referer_origin_url
+            module_specifier,
+            referer_origin_url
         );
         (self.resolve_fn)(module_specifier, referer_info)
     }
@@ -265,7 +267,7 @@ impl SourceLoader for JsonSecretsLoader {
             self.json_value.to_string().replace("`", "")
         );
 
-        info!("Loaded json secrets {}", source_code);
+        trace!("Loaded json secrets {}", source_code);
 
         return Ok(LoadedSourceCode {
             is_wasm: false,

--- a/src/ops/fetch.rs
+++ b/src/ops/fetch.rs
@@ -105,13 +105,13 @@ pub fn op_fetch(ptr: JsRuntime, base: &msg::Base, raw: fly_buf) -> Box<Op> {
     }
 
     let has_body = msg.has_body();
-    println!("HAS BODY? {}", has_body);
+    trace!("HAS BODY? {}", has_body);
     let req_body = if has_body {
         if raw.data_len > 0 {
-            println!("STATIC BODY!");
+            trace!("STATIC BODY!");
             Body::from(unsafe { slice::from_raw_parts(raw.data_ptr, raw.data_len) }.to_vec())
         } else {
-            println!("STREAMING BODY");
+            trace!("STREAMING BODY");
             let (sender, recver) = mpsc::unbounded::<Vec<u8>>();
             {
                 rt.streams.lock().unwrap().insert(req_id, sender);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -197,16 +197,16 @@ fn init_event_loop(
       el.spawn(
         rxready
           .map_err(|_| error!("error recving ready signal for runtime"))
-          .and_then(|_| Ok(warn!("ready ch received!"))),
+          .and_then(|_| Ok(trace!("ready ch received!"))),
       );
 
       match el.run() {
-        Ok(_) => warn!("runtime event loop ran fine"),
+        Ok(_) => trace!("runtime event loop ran fine"),
         Err(e) => error!("error running runtime event loop: {}", e),
       };
-      warn!("Event loop has run its course.");
+      trace!("Event loop has run its course.");
       match txquit.send(()) {
-        Ok(_) => warn!("Sent quit () in channel successfully."),
+        Ok(_) => trace!("Sent quit () in channel successfully."),
         Err(_) => error!("error sending quit signal for runtime"),
       };
     })

--- a/v8env/src/dev-tools/compiler.ts
+++ b/v8env/src/dev-tools/compiler.ts
@@ -389,7 +389,7 @@ export class Compiler {
       callback: AmdCallback,
       errback: AmdErrback
     ): void => {
-      console.log("compiler.makeLocalRequire()", { moduleInfo, deps });
+      console.trace("compiler.makeLocalRequire()", { moduleInfo, deps });
       assert(
         deps.length === 1,
         "Local require requires exactly one dependency."
@@ -491,7 +491,7 @@ function createLanguageService(compiler: Compiler): ts.LanguageService {
       return true;
     },
     fileExists(path: string): boolean {
-      console.log("Typescript ls doing file exists check.");
+      console.trace("Typescript ls doing file exists check.");
       const info = compiler.getModuleInfoByFileName(path);
       const exists = info != null;
       trace("fileExists()", { path, exists });

--- a/v8env/src/dev-tools/resolver.ts
+++ b/v8env/src/dev-tools/resolver.ts
@@ -5,7 +5,6 @@ import { URL } from "src/url";
 
 export function fetchModule(specifierUrl: string, refererOriginUrl?: string): LoadedModule {  
   console.trace("[resolver] fetchModule()", { specifierUrl, refererOriginUrl });
-  console.log(`Fetching module ${specifierUrl} from ${refererOriginUrl}`);
   // If module is a "asset" I.E. lib.dom.d.ts
   if (isAsset(specifierUrl, refererOriginUrl)) {
     const parsedUrl = new URL(specifierUrl, refererOriginUrl);
@@ -19,7 +18,7 @@ export function fetchModule(specifierUrl: string, refererOriginUrl?: string): Lo
     // Check for asset in assetSourceCode object if not error
     assert(assetName in assetSourceCode, `No such asset "${assetName}"`);
 
-    console.log(`Finished asset module fetch ${parsedUrl.toString()}`);
+    console.trace(`Finished asset module fetch ${parsedUrl.toString()}`);
 
     // Return LoadModuleResult with asset source code
     return {
@@ -31,7 +30,7 @@ export function fetchModule(specifierUrl: string, refererOriginUrl?: string): Lo
     };
   }
 
-  console.log(`Finished module fetch ${specifierUrl} from ${refererOriginUrl}`);
+  console.trace(`Finished module fetch ${specifierUrl} from ${refererOriginUrl}`);
   // Use std loadModule function to load module
   return loadModule(specifierUrl, refererOriginUrl);
 }


### PR DESCRIPTION
Filter runtime and app logs with the `FLY_LOG_LEVEL` and `LOG_LEVEL` env variables. Runtime logs default to Warning and app defaults to Debug. `distributed-fly` filters away debug and trace at compile time.