### PR TITLE
Load dev tools from binary, move embedded js to v8env.rs

### DIFF
--- a/distributed-fly/src/runtime_selector.rs
+++ b/distributed-fly/src/runtime_selector.rs
@@ -120,6 +120,7 @@ impl RuntimeSelector for DistributedRuntimeSelector {
                     app_logger: &APP_LOGGER,
                     msg_handler: None,
                     permissions: None,
+                    dev_tools: false,
                 });
                 let merged_conf = rel.clone().parsed_config().unwrap();
                 rt.eval(

--- a/src/bin/dns/main.rs
+++ b/src/bin/dns/main.rs
@@ -109,13 +109,10 @@ fn main() {
     app_logger: &app_logger,
     msg_handler: None,
     permissions: None,
+    dev_tools: true,
   });
 
-  debug!("Loading dev tools");
-  runtime.eval_file("v8env/dist/dev-tools.js");
-  runtime.eval("<installDevTools>", "installDevTools();");
-  debug!("Loading dev tools done");
-  runtime.eval(entry_file, &format!("dev.run('{}')", entry_file));
+  runtime.eval_file_with_dev_tools(entry_file);
 
   let port: u16 = match matches.value_of("port") {
     Some(pstr) => pstr.parse::<u16>().unwrap(),

--- a/src/bin/eval/main.rs
+++ b/src/bin/eval/main.rs
@@ -36,14 +36,10 @@ fn main() {
     app_logger: &app_logger,
     msg_handler: None,
     permissions: None,
+    dev_tools: true,
   });
-  debug!("Loading dev tools");
-  runtime.eval_file("v8env/dist/dev-tools.js");
-  runtime.eval("<installDevTools>", "installDevTools();");
-  debug!("Loading dev tools done");
 
   let entry_file = matches.value_of("input").unwrap();
-
-  runtime.eval(entry_file, &format!("dev.run('{}')", entry_file));
+  runtime.eval_file_with_dev_tools(entry_file);
   runtime.run().wait().unwrap();
 }

--- a/src/bin/http/main.rs
+++ b/src/bin/http/main.rs
@@ -52,13 +52,10 @@ fn main() -> Result<(), Box<::std::error::Error>> {
         app_logger: &app_logger,
         msg_handler: None,
         permissions: None,
+        dev_tools: true,
     });
 
-    debug!("Loading dev tools");
-    runtime.eval_file("v8env/dist/dev-tools.js");
-    runtime.eval("<installDevTools>", "installDevTools();");
-    debug!("Loading dev tools done");
-    runtime.eval(entry_file, &format!("dev.run('{}')", entry_file));
+    runtime.eval_file_with_dev_tools(entry_file);
 
     let bind = match matches.value_of("bind") {
         Some(b) => b,

--- a/src/bin/test/main.rs
+++ b/src/bin/test/main.rs
@@ -22,12 +22,8 @@ fn main() {
     app_logger: &app_logger,
     msg_handler: None,
     permissions: Some(RuntimePermissions::new(true)),
+    dev_tools: true,
   });
-
-  trace!("Loading dev tools");
-  rt.eval_file("v8env/dist/dev-tools.js");
-  rt.eval("<installDevTools>", "installDevTools();");
-  trace!("Loading dev tools done");
 
   let args: Vec<String> = env::args().collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub fn build_number() -> &'static str {
 pub mod build_info;
 
 pub mod js;
-
+pub mod v8env;
 pub mod errors;
 pub mod msg;
 pub mod ops;

--- a/src/ops/source_map.rs
+++ b/src/ops/source_map.rs
@@ -2,6 +2,7 @@ use crate::msg;
 use flatbuffers::FlatBufferBuilder;
 
 use crate::runtime::Runtime;
+use crate::v8env::V8ENV_SOURCEMAP;
 use libfly::*;
 
 use crate::utils::*;
@@ -11,8 +12,6 @@ use std::sync::{mpsc, Mutex};
 
 use futures::{sync::oneshot, Future};
 use std::thread;
-
-lazy_static_include_bytes!(V8ENV_SOURCEMAP, "v8env/dist/v8env.js.map");
 
 type SourceMapId = (u32, u32, String, String);
 

--- a/src/v8env.rs
+++ b/src/v8env.rs
@@ -1,0 +1,37 @@
+use libfly::*;
+use std::ffi::CString;
+use std::fs::File;
+use std::io::Read;
+use std::slice;
+
+#[cfg(not(debug_assertions))]
+const V8ENV_SNAPSHOT: &'static [u8] = include_bytes!("../v8env.bin");
+
+#[cfg(debug_assertions)]
+lazy_static! {
+  static ref V8ENV_SNAPSHOT: Box<[u8]> = {
+    let filename = "v8env/dist/v8env.js";
+    let mut file = File::open(filename).unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    let snap = unsafe {
+      let cfilename = CString::new(filename).unwrap();
+      let ccontents = CString::new(contents).unwrap();
+      js_create_snapshot(cfilename.as_ptr(), ccontents.as_ptr())
+    };
+    let bytes: Vec<u8> =
+      unsafe { slice::from_raw_parts(snap.ptr as *const u8, snap.len as usize) }.to_vec();
+    bytes.into_boxed_slice()
+  };
+}
+
+lazy_static! {
+  pub static ref FLY_SNAPSHOT: fly_simple_buf = fly_simple_buf {
+    ptr: V8ENV_SNAPSHOT.as_ptr() as *const i8,
+    len: V8ENV_SNAPSHOT.len() as i32
+  };
+}
+
+lazy_static_include_bytes!(pub V8ENV_SOURCEMAP, "v8env/dist/v8env.js.map");
+
+lazy_static_include_str!(pub DEV_TOOLS_SOURCE, "v8env/dist/dev_tools.js");

--- a/src/v8env.rs
+++ b/src/v8env.rs
@@ -34,4 +34,4 @@ lazy_static! {
 
 lazy_static_include_bytes!(pub V8ENV_SOURCEMAP, "v8env/dist/v8env.js.map");
 
-lazy_static_include_str!(pub DEV_TOOLS_SOURCE, "v8env/dist/dev_tools.js");
+lazy_static_include_str!(pub DEV_TOOLS_SOURCE, "v8env/dist/dev-tools.js");


### PR DESCRIPTION
This includes the dev tools source in binaries and an option to install them when a runtime is created. There's also a new `eval_with_dev_tools` function on runtime that the main.rs files use to kick things off. We'll be using these binaries to test customer apps for prod.