### PR TITLE
Fixed a type assertion to be compatible with other libc versions.

### DIFF
--- a/src/v8env.rs
+++ b/src/v8env.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use std::fs::File;
 use std::io::Read;
 use std::slice;
-use libc::c_char
+use libc::c_char;
 
 #[cfg(not(debug_assertions))]
 const V8ENV_SNAPSHOT: &'static [u8] = include_bytes!("../v8env.bin");

--- a/src/v8env.rs
+++ b/src/v8env.rs
@@ -3,6 +3,7 @@ use std::ffi::CString;
 use std::fs::File;
 use std::io::Read;
 use std::slice;
+use libc::c_char
 
 #[cfg(not(debug_assertions))]
 const V8ENV_SNAPSHOT: &'static [u8] = include_bytes!("../v8env.bin");
@@ -27,7 +28,7 @@ lazy_static! {
 
 lazy_static! {
   pub static ref FLY_SNAPSHOT: fly_simple_buf = fly_simple_buf {
-    ptr: V8ENV_SNAPSHOT.as_ptr() as *const i8,
+    ptr: V8ENV_SNAPSHOT.as_ptr() as *const c_char,
     len: V8ENV_SNAPSHOT.len() as i32
   };
 }


### PR DESCRIPTION
The c standard doesn't specify a int type for plain `char` so it varies between platforms. On arm the old code would error during compilation expecting a `u8` instead of `i8` value.