### PR TITLE
Fix read any file exploit

### DIFF
--- a/src/ops/modules.rs
+++ b/src/ops/modules.rs
@@ -2,6 +2,7 @@ use crate::msg;
 use flatbuffers::FlatBufferBuilder;
 
 use crate::runtime::Runtime;
+use crate::errors::permission_denied;
 use libfly::*;
 
 use crate::utils::*;
@@ -14,6 +15,10 @@ pub fn op_load_module(rt: &mut Runtime, base: &msg::Base, _raw: fly_buf) -> Box<
     let cmd_id = base.cmd_id();
     let msg = base.msg_as_load_module().unwrap();
     let specifier_url = msg.specifier_url().unwrap().to_string();
+
+    if !rt.dev_tools {
+        return odd_future(permission_denied());
+    }
 
     let referer_info = match msg.referer_origin_url() {
         Some(v) => Some(RefererInfo {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -117,6 +117,7 @@ pub struct Runtime {
   pub module_resolver_manager: Box<ModuleResolverManager>,
   pub msg_handler: Box<MessageHandler>,
   pub permissions: RuntimePermissions,
+  pub dev_tools: bool,
   metadata_cache: RwLock<HashMap<i32, Box<LoadedModule>>>,
   ready_ch: Option<oneshot::Sender<()>>,
   quit_ch: Option<oneshot::Receiver<()>>,
@@ -256,6 +257,7 @@ impl Runtime {
         .msg_handler
         .unwrap_or(Box::new(DefaultMessageHandler {})),
       permissions: config.permissions.unwrap_or_default(),
+      dev_tools: config.dev_tools,
     });
 
     (*rt).ptr.0 = unsafe {


### PR DESCRIPTION
Working on deno I realized that the load module msg can be used to read any file on the host system(see denoland/deno#1858). 
I've created a simple patch for now that just disables this when dev tools are disabled.
I might implement a better solution for this one later, but I figure this really needs to get fixed now.